### PR TITLE
Verhindert Fehlermeldung bei nicht existenztem Key

### DIFF
--- a/plugins/manager/lib/yform/manager/dataset.php
+++ b/plugins/manager/lib/yform/manager/dataset.php
@@ -283,11 +283,11 @@ class rex_yform_manager_dataset
             return $this->id;
         }
 
-        if (!$this->dataLoaded) {
-            $this->loadData();
+        if ($this->hasValue($key) {
+            return $this->data[$key];
         }
 
-        return $this->data[$key];
+        return null;
     }
 
     public function getData(): array


### PR DESCRIPTION
Wenn mit `$dataset->getValue($key)` auf einen Key zugegriffen wird, der nicht existiert, wird ein Fehler ausgeworfen (Undefined array-key). Die unschöne Meldung lässt durch ein intern vorgeschaltetes `if hasValue` verhindern. Da `hasValue` bereits eine Abfrage auf `dataLoaded` durchführt, enthällt die Abfrage in der getValue-Methhode.

siehe https://github.com/FriendsOfREDAXO/neues/issues/94#issuecomment-2306902950