### PR TITLE
Validierung im Suchformular berücksichtigen

### DIFF
--- a/lib/manager/search.php
+++ b/lib/manager/search.php
@@ -109,6 +109,10 @@ class rex_yform_manager_search
 
         $yform = $this->getYForm();
         $yform->getForm();
+        if( $yform->hasWarnings() ) {
+            return $query;
+        }
+
         $fieldValues = $yform->getFieldValue();
 
         $vars = [];


### PR DESCRIPTION
Das Problem fiel mir bei einem Custom-Value auf. In einem einfachen Eingabefeld (text) sollten drei Begriffe (Breitengrad Längengrad Radius) für eine Umkreissuche eingegeben werden. Um das richtige Format sicherzustellen wurde auch ein Custom-Validator hinzugefügt. Der Validator macht seine Arbeit wie er soll. Aber die Query wurde dennoch (mit ungeeigneten Werten) gefüllt, was in einer Exception mündete.

Mit der hier eingebauten Abfrage nach Ausführen des Such-Formulars wird ohne Veränderung der Query abgebrochen. Somit werden Liste und Suchformular (nun mit Fehlermeldung) angezeigt.

<img width="1409" alt="grafik" src="https://github.com/user-attachments/assets/a1d17967-88bf-435e-a8ea-cd719b623302" />

-------

Falls sonst noch wer auf das Problem stößt: ich helfe mir jetzt mit doppelter Fehleranalyse: mit dem Custom-Validator für das Formular und dasselbe zusätzlich in value_class::getSearchFilter.
